### PR TITLE
Dedicated `bev` command with support for auto complete

### DIFF
--- a/.local/bin/bev.sh
+++ b/.local/bin/bev.sh
@@ -66,3 +66,25 @@ brun()
   cd $originalDir
   $HOME/.local/bin/brun.rb $repoDir/bev.yml
 }
+
+bev()
+{
+  case $1 in
+  cd)
+    bcd $2
+  ;;
+  clone)
+    bclone $2
+  ;;
+  openpr)
+    bopenpr $2
+  ;;
+  run)
+    brun $2
+  ;;
+  *)
+    echo "not yet implemented"
+    return 1
+  ;;
+  esac
+}

--- a/.local/share/zsh_completion.d/_bev
+++ b/.local/share/zsh_completion.d/_bev
@@ -1,0 +1,26 @@
+#compdef bev
+
+_bev() { 
+    local curcontext="$curcontext" state line
+    typeset -A opt_args
+
+    _arguments \
+        '1:bev cmds:->cmd'\
+        '2:subcmd:->args'\
+
+    case $state in
+    cmd)
+        _arguments '1:bev cmds:(cd clone openpr run)'
+    ;;
+    args)
+        case $words[2] in
+          cd)
+            _alternative 'arg::_path_files -W "$HOME/src/github.com" -/'
+          ;;
+          *)
+            _files 
+          esac
+    esac
+}
+
+_bev "$@"

--- a/.zsh_alias
+++ b/.zsh_alias
@@ -1,4 +1,5 @@
 alias vim='VIMRUNTIME="$HOME/.local/share/nvim/runtime" nvim'
+alias b=bev
 alias cat=bat
 alias mk=make
 alias cdw="cd $HOME/src/github.com/"

--- a/.zsh_env
+++ b/.zsh_env
@@ -1,7 +1,7 @@
 export PATH=/opt/mattermost:$HOME/.cargo/bin:$HOME/.gvm/gos/go1.11.4/bin:$HOME/.local/bin:$PATH
 export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-source $HOME/.local/bin/bev
+source $HOME/.local/bin/bev.sh
 
 [[ -s "$HOME/.gvm/scripts/gvm" ]] && source "$HOME/.gvm/scripts/gvm"
 [[ -e "/usr/bin/xdotool" ]] && export WINDOWID=$(xdotool getwindowfocus)

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ git pull origin master
 
 ## Bev
 
-`bev` provides few useful commands that increase my productivity. `bev` assumes all git source directory locate at `$HOME/src/github.com/`. All `bev` commands prefixes with `b-<cmd>`.
+`bev` provides few useful commands that increase my productivity. `bev` assumes all git source directory locate at `$HOME/src/github.com/`.
 
 
-### bcd
+### bev cd (alias to bcd)
 
 `cd` into a project locate in `$HOME/src/github.com`, also supports zsh-autosuggest prompt. 
 
-### bclone
+### bev clone (alias to bclone)
 
 `git clone` a repository from github into `$HOME/src/github.com/` and `cd` into the project directory. It reads from `.gitconfig` for username for github. 
 
@@ -39,7 +39,7 @@ Cloning public repo of other users:
 bclone <git-username>/<repo-name>
 ```
 
-### bopenpr
+### bev openpr (alias to bopenpr)
 
 Open github PRs if opened inside a git directory if the current branch is not master branch.
 
@@ -47,7 +47,7 @@ Open github PRs if opened inside a git directory if the current branch is not ma
 bopenpr
 ```
 
-### brun
+### bev run (alias to brun)
 
 At the root of the project create `bev.yml` file, currently only `run` command is supported.
 


### PR DESCRIPTION
Laying the foundation for #5 
Currently have implemented:
``` bash
bev cd
bev run
bev openpr
bev clone
```
`bev cd` auto complete works too.
